### PR TITLE
fix issue #1

### DIFF
--- a/lib/ReactComponentWithPureRenderMixin.js
+++ b/lib/ReactComponentWithPureRenderMixin.js
@@ -1,0 +1,1 @@
+module.exports = require('standalone-react-addons-pure-render-mixin');


### PR DESCRIPTION
Remarks:
Creating lib/ReactComponentWithPureRenderMixin.js should be enough.
Adding standalone-react-addons-pure-render-mixin into package.json seems to be unnecessary as it is already referenced in preact-compat.